### PR TITLE
Correct xml tag from lines to line

### DIFF
--- a/clover/__init__.py
+++ b/clover/__init__.py
@@ -123,7 +123,7 @@ class Cobertura(object):
                 covered_statements = 0
                 conditions = 0
                 covered_conditions = 0
-                for line in class_info.iter('lines'):
+                for line in class_info.iter('line'):
                     statements += 1
                     if line.get('hits') == '1':
                         covered_statements += 1


### PR DESCRIPTION
Tried to generate coverage 4.0 xml to clover for bamboo but could not get correct numbers. So started to troubleshoot and found the code were looking for lines xml tags but input files has line (singular). With this changes bamboo can show correct coverage numbers.
