### PR TITLE
Require Python 3.6+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,4 +85,5 @@ setup(
         "coverage==5.3",
         "pygount==1.2.4",
     ],
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
I noticed that you decided to drop support for Python 3.4 / 3.5. However, you didn't put this detail into your setup.py.
This may cause trouble for people who are using your library. Because PIP will resolve the latest version even on Python 3.4.

This patch should fix the problem. I recommend you to drop the current 3.y.z PIP packages and release a new one with this patch (so you will not cause troubles to people).

For Python 3.4 it package will definitely not work due to coverage package dependency. They dropped Python 3.4 support in 5.0 Alpha - https://github.com/nedbat/coveragepy/releases/tag/coverage-5.0a5