### PR TITLE
fix TypeError not NoneType

### DIFF
--- a/clover/__init__.py
+++ b/clover/__init__.py
@@ -67,6 +67,8 @@ class Class(object):
             # Old version of coverage
             sources = [""]
         for source in sources:
+            if not source:
+                continue
             filename = os.path.join(source, self.filename)
             try:
                 analysis = SourceAnalysis.from_file(


### PR DESCRIPTION
```
$ coverage2clover -i coverage.xml -o clover.xml

Traceback (most recent call last):
  File "/usr/local/bin/coverage2clover", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/clover/coverage2clover.py", line 35, in main
    cov.open(inputfile)
  File "/usr/local/lib/python3.8/site-packages/clover/__init__.py", line 147, in open
    c.count_loc(sources)
  File "/usr/local/lib/python3.8/site-packages/clover/__init__.py", line 70, in count_loc
    filename = os.path.join(source, self.filename)
  File "/usr/local/lib/python3.8/posixpath.py", line 76, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```